### PR TITLE
[docs] Fix memory leak in example of the man page for `CURLOPT_WRITEFUNCTION`

### DIFF
--- a/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.3
+++ b/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.3
@@ -109,6 +109,9 @@ For all protocols
 
  /* we pass our 'chunk' struct to the callback function */
  curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, (void *)&chunk);
+
+ /* remember to free the buffer */
+ free(chunk.response)
 .fi
 .SH AVAILABILITY
 Support for the CURL_WRITEFUNC_PAUSE return code was added in version 7.18.0.


### PR DESCRIPTION
Fixes #10387